### PR TITLE
ci: add cross-platform build support for GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,10 +11,58 @@ on:
 
 jobs:
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+
+    - name: Set up Go
+      uses: actions/setup-go@v6
+      with:
+        go-version: '1.26'
+
+    - name: Test
+      run: |
+        go test -v ./...
+
   build:
+    needs: test
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - platform: windows-amd64
+            goos: windows
+            goarch: amd64
+            ext: .exe
+            package: zip
+          - platform: windows-arm64
+            goos: windows
+            goarch: arm64
+            ext: .exe
+            package: zip
+          - platform: linux-amd64
+            goos: linux
+            goarch: amd64
+            ext: ""
+            package: tar.gz
+          - platform: linux-arm64
+            goos: linux
+            goarch: arm64
+            ext: ""
+            package: tar.gz
+          - platform: darwin-amd64
+            goos: darwin
+            goarch: amd64
+            ext: ""
+            package: tar.gz
+          - platform: darwin-arm64
+            goos: darwin
+            goarch: arm64
+            ext: ""
+            package: tar.gz
     steps:
     - uses: actions/checkout@v6
 
@@ -26,18 +74,45 @@ jobs:
     - name: Build binaries
       env:
         CGO_ENABLED: 0
+        GOOS: ${{ matrix.goos }}
+        GOARCH: ${{ matrix.goarch }}
       run: |
-        go build -ldflags="-s -w" -o checkhash ./cmd/checkhash
-        go build -ldflags="-s -w" -o decrypt ./cmd/decrypt
-    - name: Create tarball
+        go build -ldflags="-s -w" -o checkhash${{ matrix.ext }} ./cmd/checkhash
+        go build -ldflags="-s -w" -o decrypt${{ matrix.ext }} ./cmd/decrypt
+
+    - name: Create zip package
+      if: matrix.package == 'zip'
       run: |
-        tar -czvf kobackupcipher-${{ github.sha }}.tar.gz \
-          checkhash \
-          decrypt
+        zip -r kobackupcipher-${{ matrix.platform }}-${{ github.sha }}.zip checkhash${{ matrix.ext }} decrypt${{ matrix.ext }}
+
+    - name: Create tar.gz package
+      if: matrix.package == 'tar.gz'
+      run: |
+        tar -czvf kobackupcipher-${{ matrix.platform }}-${{ github.sha }}.tar.gz \
+          checkhash${{ matrix.ext }} \
+          decrypt${{ matrix.ext }}
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: kobackupcipher-${{ matrix.platform }}
+        path: |
+          kobackupcipher-${{ matrix.platform }}-${{ github.sha }}.zip
+          kobackupcipher-${{ matrix.platform }}-${{ github.sha }}.tar.gz
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: artifacts
+
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
-        files: kobackupcipher-${{ github.sha }}.tar.gz
+        files: artifacts/*/*
         generate_release_notes: true
         tag_name: "auto-release-${{ github.sha }}"
         name: "auto-release-${{ github.sha }}"


### PR DESCRIPTION
- Add 6-platform build matrix: windows-amd64, windows-arm64, linux-amd64, linux-arm64, darwin-amd64, darwin-arm64
- Use Go cross-compilation with GOOS/GOARCH environment variables
- Use Linux native commands (zip/tar) for packaging instead of PowerShell
- Add separate test job and release job for artifacts